### PR TITLE
Calling `.quit` should disable reconnects.

### DIFF
--- a/index.js
+++ b/index.js
@@ -135,8 +135,10 @@ RedisSentinelClient.prototype._connectSentinel = function (port, host) {
   this.sentinelTalker.on('end', function(){
     debug('sentinel talker disconnected at ' + host + ':' + port);
     if (!isDisconnected) {
-      isDisconnected = true
-      self.emit('sentinel disconnected')
+      isDisconnected = true;
+      if (!self.sentinelTalker.closing) {
+        self.emit('sentinel disconnected');
+      }
     }
   });
 
@@ -153,7 +155,9 @@ RedisSentinelClient.prototype._connectSentinel = function (port, host) {
     debug('sentinel listener disconnected at ' + host + ':' + port);
     if (!isDisconnected) {
       isDisconnected = true
-      self.emit('sentinel disconnected')
+      if (!self.sentinelListener.closing) {
+        self.emit('sentinel disconnected');
+      }
     }
   });
 


### PR DESCRIPTION
Right now, calling `.quit` will cause an automatic reconnect of the sentinel talker and listener connections, which prevents closing the redis connection cleanly when using `redis-sentinel-client`.